### PR TITLE
Add context for xml and wikitext

### DIFF
--- a/runtime/queries/wikitext/context.scm
+++ b/runtime/queries/wikitext/context.scm
@@ -1,0 +1,1 @@
+(section) @context

--- a/runtime/queries/xml/context.scm
+++ b/runtime/queries/xml/context.scm
@@ -1,0 +1,1 @@
+(element) @context


### PR DESCRIPTION
Wikitext went in master a few days ago.
<img width="1366" height="549" alt="screenshot-2025-09-18-165201" src="https://github.com/user-attachments/assets/7d4e8f18-0b99-4800-8994-138a50d401d3" />

I think your work on sticky context will help to bring folding code closer.  Thanks.
